### PR TITLE
feat: add training loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ uv sync --dev
 - BERT backbone with stacked encoder blocks and pooled `[CLS]` output
 - masked language modeling corruption and MLM prediction head
 - sequence classification head for emotion analysis
+- sequence-classification training, evaluation, and checkpointing

--- a/src/bert/checkpoint.py
+++ b/src/bert/checkpoint.py
@@ -1,0 +1,41 @@
+"""Checkpoint save/load helpers for the BERT study project."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import torch
+
+from .classification import BertForSequenceClassification
+from .model import BertConfig
+from .tokenizer import WordPieceTokenizer
+
+
+def save_sequence_classification_checkpoint(
+    path: Path,
+    *,
+    model: BertForSequenceClassification,
+    tokenizer: WordPieceTokenizer,
+    config: BertConfig,
+    labels: list[str],
+) -> None:
+    payload = {
+        "model_state_dict": model.state_dict(),
+        "tokenizer": tokenizer.to_dict(),
+        "config": config.__dict__.copy(),
+        "labels": labels,
+    }
+    torch.save(payload, path)
+
+
+def load_sequence_classification_checkpoint(
+    path: Path,
+) -> tuple[BertForSequenceClassification, WordPieceTokenizer, BertConfig, list[str]]:
+    payload = torch.load(path, weights_only=False)
+    config = BertConfig(**payload["config"])
+    labels = [str(label) for label in payload["labels"]]
+    tokenizer = WordPieceTokenizer.from_dict(payload["tokenizer"])
+    model = BertForSequenceClassification(config, num_labels=len(labels))
+    model.load_state_dict(payload["model_state_dict"])
+    model.eval()
+    return model, tokenizer, config, labels

--- a/src/bert/cli.py
+++ b/src/bert/cli.py
@@ -4,7 +4,17 @@ from argparse import ArgumentParser
 from collections.abc import Sequence
 from pathlib import Path
 
+from .checkpoint import (
+    load_sequence_classification_checkpoint,
+    save_sequence_classification_checkpoint,
+)
+from .data import build_label_vocabulary, load_classification_examples, split_examples
 from .tokenizer import WordPieceTokenizer
+from .training import (
+    SequenceClassificationTrainingConfig,
+    evaluate_sequence_classifier,
+    train_sequence_classifier,
+)
 
 
 def build_parser() -> ArgumentParser:
@@ -25,6 +35,32 @@ def build_parser() -> ArgumentParser:
         help="Optional newline-delimited corpus used to fit the tokenizer.",
     )
     tokenize_parser.add_argument("--vocab-size", type=int, default=64)
+
+    train_parser = subparsers.add_parser(
+        "train-classifier",
+        help="Train a minimal BERT sequence classifier from a JSONL dataset.",
+    )
+    train_parser.add_argument("dataset", type=Path)
+    train_parser.add_argument("--checkpoint-out", type=Path)
+    train_parser.add_argument("--validation-fraction", type=float, default=0.2)
+    train_parser.add_argument("--vocab-size", type=int, default=128)
+    train_parser.add_argument("--hidden-size", type=int, default=64)
+    train_parser.add_argument("--max-position-embeddings", type=int, default=128)
+    train_parser.add_argument("--num-hidden-layers", type=int, default=2)
+    train_parser.add_argument("--num-heads", type=int, default=4)
+    train_parser.add_argument("--intermediate-size", type=int, default=256)
+    train_parser.add_argument("--batch-size", type=int, default=8)
+    train_parser.add_argument("--learning-rate", type=float, default=3e-4)
+    train_parser.add_argument("--num-epochs", type=int, default=10)
+    train_parser.add_argument("--seed", type=int, default=0)
+
+    evaluate_parser = subparsers.add_parser(
+        "evaluate-classifier",
+        help="Evaluate a saved sequence classification checkpoint on a JSONL dataset.",
+    )
+    evaluate_parser.add_argument("checkpoint", type=Path)
+    evaluate_parser.add_argument("dataset", type=Path)
+    evaluate_parser.add_argument("--batch-size", type=int, default=8)
     return parser
 
 
@@ -40,3 +76,58 @@ def main(argv: Sequence[str] | None = None) -> None:
         print(f"tokens={encoding.tokens}")
         print(f"token_ids={encoding.token_ids}")
         print(f"token_type_ids={encoding.token_type_ids}")
+        return
+
+    if args.command == "train-classifier":
+        examples = load_classification_examples(args.dataset)
+        train_examples, validation_examples = split_examples(
+            examples,
+            validation_fraction=args.validation_fraction,
+            seed=args.seed,
+        )
+        label_to_id, labels = build_label_vocabulary(examples)
+        training_config = SequenceClassificationTrainingConfig(
+            vocab_size=args.vocab_size,
+            hidden_size=args.hidden_size,
+            max_position_embeddings=args.max_position_embeddings,
+            num_hidden_layers=args.num_hidden_layers,
+            num_heads=args.num_heads,
+            intermediate_size=args.intermediate_size,
+            batch_size=args.batch_size,
+            learning_rate=args.learning_rate,
+            num_epochs=args.num_epochs,
+            seed=args.seed,
+        )
+        artifacts = train_sequence_classifier(
+            train_examples,
+            validation_examples,
+            label_to_id=label_to_id,
+            labels=labels,
+            training_config=training_config,
+        )
+        print(f"final_train_loss={artifacts.train_losses[-1]:.4f}")
+        print(f"validation_accuracy={artifacts.validation_accuracy:.4f}")
+        print(f"labels={artifacts.labels}")
+        if args.checkpoint_out is not None:
+            save_sequence_classification_checkpoint(
+                args.checkpoint_out,
+                model=artifacts.model,
+                tokenizer=artifacts.tokenizer,
+                config=artifacts.config,
+                labels=artifacts.labels,
+            )
+            print(f"checkpoint={args.checkpoint_out}")
+        return
+
+    if args.command == "evaluate-classifier":
+        model, tokenizer, _, labels = load_sequence_classification_checkpoint(args.checkpoint)
+        examples = load_classification_examples(args.dataset)
+        label_to_id = {label: index for index, label in enumerate(labels)}
+        accuracy = evaluate_sequence_classifier(
+            model,
+            tokenizer,
+            examples,
+            label_to_id=label_to_id,
+            batch_size=args.batch_size,
+        )
+        print(f"accuracy={accuracy:.4f}")

--- a/src/bert/data.py
+++ b/src/bert/data.py
@@ -1,0 +1,58 @@
+"""Dataset helpers for sentence-level classification experiments."""
+
+from __future__ import annotations
+
+import json
+import random
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ClassificationExample:
+    text: str
+    label: str
+
+
+def load_classification_examples(path: Path) -> list[ClassificationExample]:
+    examples: list[ClassificationExample] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        payload = json.loads(line)
+        text = payload.get("text")
+        label = payload.get("label")
+        if not isinstance(text, str) or not isinstance(label, str):
+            msg = "each JSONL row must contain string fields 'text' and 'label'"
+            raise ValueError(msg)
+        examples.append(ClassificationExample(text=text, label=label))
+
+    if not examples:
+        msg = f"no classification examples found in {path}"
+        raise ValueError(msg)
+    return examples
+
+
+def build_label_vocabulary(
+    examples: list[ClassificationExample],
+) -> tuple[dict[str, int], list[str]]:
+    labels = sorted({example.label for example in examples})
+    label_to_id = {label: index for index, label in enumerate(labels)}
+    return label_to_id, labels
+
+
+def split_examples(
+    examples: list[ClassificationExample],
+    *,
+    validation_fraction: float = 0.2,
+    seed: int = 0,
+) -> tuple[list[ClassificationExample], list[ClassificationExample]]:
+    if not 0.0 < validation_fraction < 1.0:
+        msg = "validation_fraction must be between 0 and 1"
+        raise ValueError(msg)
+
+    shuffled = list(examples)
+    random.Random(seed).shuffle(shuffled)
+    split_index = max(1, int(len(shuffled) * (1.0 - validation_fraction)))
+    split_index = min(split_index, len(shuffled) - 1)
+    return shuffled[:split_index], shuffled[split_index:]

--- a/src/bert/training.py
+++ b/src/bert/training.py
@@ -1,0 +1,141 @@
+"""Training and evaluation helpers for sequence classification."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+from .batching import encode_text_batch
+from .classification import BertForSequenceClassification
+from .data import ClassificationExample
+from .model import BertConfig
+from .tokenizer import WordPieceTokenizer
+
+
+@dataclass(frozen=True)
+class SequenceClassificationTrainingConfig:
+    vocab_size: int = 128
+    hidden_size: int = 64
+    max_position_embeddings: int = 128
+    num_hidden_layers: int = 2
+    num_heads: int = 4
+    intermediate_size: int = 256
+    batch_size: int = 8
+    learning_rate: float = 3e-4
+    num_epochs: int = 10
+    seed: int = 0
+
+
+@dataclass(frozen=True)
+class SequenceClassificationArtifacts:
+    model: BertForSequenceClassification
+    tokenizer: WordPieceTokenizer
+    config: BertConfig
+    labels: list[str]
+    train_losses: list[float]
+    validation_accuracy: float
+
+
+def _build_batches(
+    examples: list[ClassificationExample],
+    *,
+    batch_size: int,
+) -> list[list[ClassificationExample]]:
+    return [examples[index : index + batch_size] for index in range(0, len(examples), batch_size)]
+
+
+def evaluate_sequence_classifier(
+    model: BertForSequenceClassification,
+    tokenizer: WordPieceTokenizer,
+    examples: list[ClassificationExample],
+    *,
+    label_to_id: dict[str, int],
+    batch_size: int,
+) -> float:
+    model.eval()
+    correct = 0
+    total = 0
+
+    with torch.no_grad():
+        for batch_examples in _build_batches(examples, batch_size=batch_size):
+            batch = encode_text_batch(tokenizer, [example.text for example in batch_examples])
+            labels = torch.tensor(
+                [label_to_id[example.label] for example in batch_examples],
+                dtype=torch.long,
+            )
+            logits, _ = model(
+                batch.token_ids,
+                batch.token_type_ids,
+                attention_mask=batch.attention_mask,
+            )
+            predictions = logits.argmax(dim=-1)
+            correct += int((predictions == labels).sum().item())
+            total += labels.numel()
+
+    return correct / total
+
+
+def train_sequence_classifier(
+    train_examples: list[ClassificationExample],
+    validation_examples: list[ClassificationExample],
+    *,
+    label_to_id: dict[str, int],
+    labels: list[str],
+    training_config: SequenceClassificationTrainingConfig,
+) -> SequenceClassificationArtifacts:
+    torch.manual_seed(training_config.seed)
+
+    tokenizer = WordPieceTokenizer.fit(
+        [example.text for example in train_examples],
+        vocab_size=training_config.vocab_size,
+        min_frequency=1,
+    )
+    config = BertConfig(
+        vocab_size=tokenizer.vocab_size,
+        hidden_size=training_config.hidden_size,
+        max_position_embeddings=training_config.max_position_embeddings,
+        num_hidden_layers=training_config.num_hidden_layers,
+        num_heads=training_config.num_heads,
+        intermediate_size=training_config.intermediate_size,
+        hidden_dropout_prob=0.0,
+    )
+    model = BertForSequenceClassification(config, num_labels=len(labels))
+    optimizer = torch.optim.AdamW(model.parameters(), lr=training_config.learning_rate)
+
+    train_losses: list[float] = []
+    for _ in range(training_config.num_epochs):
+        model.train()
+        for batch_examples in _build_batches(train_examples, batch_size=training_config.batch_size):
+            batch = encode_text_batch(tokenizer, [example.text for example in batch_examples])
+            labels_tensor = torch.tensor(
+                [label_to_id[example.label] for example in batch_examples],
+                dtype=torch.long,
+            )
+            _, loss = model(
+                batch.token_ids,
+                batch.token_type_ids,
+                attention_mask=batch.attention_mask,
+                labels=labels_tensor,
+            )
+            assert loss is not None
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+            train_losses.append(float(loss.item()))
+
+    validation_accuracy = evaluate_sequence_classifier(
+        model,
+        tokenizer,
+        validation_examples,
+        label_to_id=label_to_id,
+        batch_size=training_config.batch_size,
+    )
+    return SequenceClassificationArtifacts(
+        model=model,
+        tokenizer=tokenizer,
+        config=config,
+        labels=labels,
+        train_losses=train_losses,
+        validation_accuracy=validation_accuracy,
+    )

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,0 +1,93 @@
+import json
+from pathlib import Path
+
+from bert.checkpoint import (
+    load_sequence_classification_checkpoint,
+    save_sequence_classification_checkpoint,
+)
+from bert.data import build_label_vocabulary, load_classification_examples, split_examples
+from bert.training import SequenceClassificationTrainingConfig, train_sequence_classifier
+
+
+def test_load_classification_examples_reads_jsonl(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "dataset.jsonl"
+    dataset_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"text": "I feel great", "label": "joy"}),
+                json.dumps({"text": "I feel awful", "label": "sadness"}),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    examples = load_classification_examples(dataset_path)
+
+    assert [(example.text, example.label) for example in examples] == [
+        ("I feel great", "joy"),
+        ("I feel awful", "sadness"),
+    ]
+
+
+def test_train_sequence_classifier_returns_artifacts_and_checkpoint_round_trip(
+    tmp_path: Path,
+) -> None:
+    examples = [
+        {"text": "I feel happy", "label": "joy"},
+        {"text": "This is wonderful", "label": "joy"},
+        {"text": "I feel sad", "label": "sadness"},
+        {"text": "This is terrible", "label": "sadness"},
+    ]
+    dataset_path = tmp_path / "dataset.jsonl"
+    dataset_path.write_text(
+        "\n".join(json.dumps(example) for example in examples),
+        encoding="utf-8",
+    )
+
+    loaded_examples = load_classification_examples(dataset_path)
+    train_examples, validation_examples = split_examples(
+        loaded_examples,
+        validation_fraction=0.5,
+        seed=0,
+    )
+    label_to_id, labels = build_label_vocabulary(loaded_examples)
+
+    artifacts = train_sequence_classifier(
+        train_examples,
+        validation_examples,
+        label_to_id=label_to_id,
+        labels=labels,
+        training_config=SequenceClassificationTrainingConfig(
+            vocab_size=32,
+            hidden_size=16,
+            max_position_embeddings=16,
+            num_hidden_layers=1,
+            num_heads=2,
+            intermediate_size=32,
+            batch_size=2,
+            learning_rate=1e-3,
+            num_epochs=1,
+            seed=0,
+        ),
+    )
+
+    assert artifacts.labels == labels
+    assert artifacts.train_losses
+    assert 0.0 <= artifacts.validation_accuracy <= 1.0
+
+    checkpoint_path = tmp_path / "classifier.pt"
+    save_sequence_classification_checkpoint(
+        checkpoint_path,
+        model=artifacts.model,
+        tokenizer=artifacts.tokenizer,
+        config=artifacts.config,
+        labels=artifacts.labels,
+    )
+    restored_model, restored_tokenizer, restored_config, restored_labels = (
+        load_sequence_classification_checkpoint(checkpoint_path)
+    )
+
+    assert restored_labels == artifacts.labels
+    assert restored_tokenizer.vocab == artifacts.tokenizer.vocab
+    assert restored_config.hidden_size == artifacts.config.hidden_size
+    assert restored_model.classifier.out_features == len(labels)


### PR DESCRIPTION
## 概要
- sequence classification の training / evaluation / checkpointing を追加
- JSONL データセットから emotion classification を fine-tuning できる最小 CLI を追加
- training 系の unit test を追加

## 変更内容
- `src/bert/data.py` を追加
- `src/bert/checkpoint.py` を追加
- `src/bert/training.py` を追加
- `src/bert/cli.py` に `train-classifier`, `evaluate-classifier` を追加
- `tests/test_training.py` を追加
- `README.md` の current scope を更新

## 確認
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest`
- `uv run python -m bert --help`

close #11
