### PR TITLE
feat: add inference cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ uv sync --dev
 - masked language modeling corruption and MLM prediction head
 - sequence classification head for emotion analysis
 - sequence-classification training, evaluation, and checkpointing
+- inference CLI for sentence-level emotion prediction

--- a/src/bert/cli.py
+++ b/src/bert/cli.py
@@ -9,6 +9,7 @@ from .checkpoint import (
     save_sequence_classification_checkpoint,
 )
 from .data import build_label_vocabulary, load_classification_examples, split_examples
+from .inference import predict_sequence_class
 from .tokenizer import WordPieceTokenizer
 from .training import (
     SequenceClassificationTrainingConfig,
@@ -61,6 +62,13 @@ def build_parser() -> ArgumentParser:
     evaluate_parser.add_argument("checkpoint", type=Path)
     evaluate_parser.add_argument("dataset", type=Path)
     evaluate_parser.add_argument("--batch-size", type=int, default=8)
+
+    predict_parser = subparsers.add_parser(
+        "predict-classifier",
+        help="Run sentence-level emotion prediction from a saved checkpoint.",
+    )
+    predict_parser.add_argument("checkpoint", type=Path)
+    predict_parser.add_argument("text")
     return parser
 
 
@@ -131,3 +139,15 @@ def main(argv: Sequence[str] | None = None) -> None:
             batch_size=args.batch_size,
         )
         print(f"accuracy={accuracy:.4f}")
+        return
+
+    if args.command == "predict-classifier":
+        model, tokenizer, _, labels = load_sequence_classification_checkpoint(args.checkpoint)
+        prediction, scores = predict_sequence_class(
+            model,
+            tokenizer,
+            args.text,
+            labels=labels,
+        )
+        print(f"prediction={prediction}")
+        print(f"scores={scores}")

--- a/src/bert/inference.py
+++ b/src/bert/inference.py
@@ -1,0 +1,35 @@
+"""Inference helpers for sentence-level classification."""
+
+from __future__ import annotations
+
+import torch
+
+from .batching import encode_text_batch
+from .classification import BertForSequenceClassification
+from .tokenizer import WordPieceTokenizer
+
+
+def predict_sequence_class(
+    model: BertForSequenceClassification,
+    tokenizer: WordPieceTokenizer,
+    text: str,
+    *,
+    labels: list[str],
+) -> tuple[str, dict[str, float]]:
+    model.eval()
+    batch = encode_text_batch(tokenizer, [text])
+
+    with torch.no_grad():
+        logits, _ = model(
+            batch.token_ids,
+            batch.token_type_ids,
+            attention_mask=batch.attention_mask,
+        )
+        probabilities = torch.softmax(logits[0], dim=-1)
+
+    scores = {
+        label: float(probability)
+        for label, probability in zip(labels, probabilities.tolist(), strict=True)
+    }
+    prediction = labels[int(probabilities.argmax().item())]
+    return prediction, scores

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,0 +1,97 @@
+from pathlib import Path
+
+from bert.checkpoint import (
+    load_sequence_classification_checkpoint,
+    save_sequence_classification_checkpoint,
+)
+from bert.classification import BertForSequenceClassification
+from bert.inference import predict_sequence_class
+from bert.model import BertConfig
+from bert.tokenizer import WordPieceTokenizer
+
+
+def test_predict_sequence_class_returns_label_and_scores() -> None:
+    tokenizer = WordPieceTokenizer(
+        vocab=[
+            "[PAD]",
+            "[CLS]",
+            "[SEP]",
+            "[MASK]",
+            "[UNK]",
+            "i",
+            "feel",
+            "great",
+        ]
+    )
+    model = BertForSequenceClassification(
+        BertConfig(
+            vocab_size=tokenizer.vocab_size,
+            hidden_size=8,
+            max_position_embeddings=8,
+            num_hidden_layers=1,
+            num_heads=2,
+            intermediate_size=16,
+            hidden_dropout_prob=0.0,
+        ),
+        num_labels=2,
+    )
+    labels = ["joy", "sadness"]
+
+    prediction, scores = predict_sequence_class(
+        model,
+        tokenizer,
+        "I feel great",
+        labels=labels,
+    )
+
+    assert prediction in labels
+    assert set(scores) == set(labels)
+    assert abs(sum(scores.values()) - 1.0) < 1e-6
+
+
+def test_sequence_classification_checkpoint_supports_inference(tmp_path: Path) -> None:
+    tokenizer = WordPieceTokenizer(
+        vocab=[
+            "[PAD]",
+            "[CLS]",
+            "[SEP]",
+            "[MASK]",
+            "[UNK]",
+            "i",
+            "feel",
+            "bad",
+        ]
+    )
+    config = BertConfig(
+        vocab_size=tokenizer.vocab_size,
+        hidden_size=8,
+        max_position_embeddings=8,
+        num_hidden_layers=1,
+        num_heads=2,
+        intermediate_size=16,
+        hidden_dropout_prob=0.0,
+    )
+    model = BertForSequenceClassification(config, num_labels=2)
+    checkpoint_path = tmp_path / "classifier.pt"
+    labels = ["joy", "sadness"]
+
+    save_sequence_classification_checkpoint(
+        checkpoint_path,
+        model=model,
+        tokenizer=tokenizer,
+        config=config,
+        labels=labels,
+    )
+    restored_model, restored_tokenizer, _, restored_labels = (
+        load_sequence_classification_checkpoint(checkpoint_path)
+    )
+
+    prediction, scores = predict_sequence_class(
+        restored_model,
+        restored_tokenizer,
+        "I feel bad",
+        labels=restored_labels,
+    )
+
+    assert prediction in restored_labels
+    assert set(scores) == set(restored_labels)


### PR DESCRIPTION
## 概要
- saved classifier checkpoint から生テキストを推論する CLI を追加
- sequence classification inference helper を追加
- inference の unit test を追加

## 変更内容
- `src/bert/inference.py` を追加
- `predict_sequence_class()` を追加
- `src/bert/cli.py` に `predict-classifier` を追加
- `tests/test_inference.py` を追加
- `README.md` の current scope を更新

## 確認
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest`
- `uv run python -m bert --help`

close #12
